### PR TITLE
State forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.5.1](https://github.com///compare/v1.3.0...v1.5.1) (2023-03-10)
+
 ## [1.5.0](https://github.com///compare/v1.3.0...v1.5.0) (2023-03-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.5.2](https://github.com///compare/v1.5.1...v1.5.2) (2023-03-13)
+
 ### [1.5.1](https://github.com///compare/v1.3.0...v1.5.1) (2023-03-10)
 
 ## [1.5.0](https://github.com///compare/v1.3.0...v1.5.0) (2023-03-01)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/event-capture-client",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "send event data to api",
   "repository": "https://github.com/TomWoodward/@openstax/event-capture-client",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openstax/event-capture-client",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "send event data to api",
   "repository": "https://github.com/TomWoodward/@openstax/event-capture-client",
   "main": "index.js",

--- a/src/events.ts
+++ b/src/events.ts
@@ -5,7 +5,7 @@ import { InteractedElementV1ToJSON, InteractedElementV1TypeEnum } from "./api/mo
 import { NudgedV1ToJSON, NudgedV1TypeEnum } from "./api/models/NudgedV1";
 import { StartedSessionV1ToJSON, StartedSessionV1TypeEnum } from "./api/models/StartedSessionV1";
 import { createEvent } from "./lib/events";
-import { clientClockProvider, createSessionProvider, referrerProvider, serviceWorkerStateProvider, sourceUriProvider, typeProvider } from "./providers";
+import { clientClockProvider, createSessionProvider, referrerProvider, serviceWorkerStateProvider, sourceUriProvider, stateChangePrevious, typeProvider } from "./providers";
 
 export { createEvent };
 
@@ -50,7 +50,10 @@ export const interacted = createEvent(InteractedElementV1ToJSON,
 
 export const stateChange = createEvent(ChangedStateV1ToJSON,
   typeProvider(ChangedStateV1TypeEnum.OrgOpenstaxEcChangedStateV1),
+  stateChangePrevious(),
   clientClockProvider,
   sourceUriProvider(),
   sessionProvider
 );
+
+stateChange({});

--- a/src/events.ts
+++ b/src/events.ts
@@ -55,5 +55,3 @@ export const stateChange = createEvent(ChangedStateV1ToJSON,
   sourceUriProvider(),
   sessionProvider
 );
-
-stateChange({});

--- a/src/providers.spec.ts
+++ b/src/providers.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 
-import { clientClockProvider, createSessionProvider, referrerProvider, serviceWorkerStateProvider, sourceUriProvider } from "./providers";
+import { clientClockProvider, createSessionProvider, referrerProvider, serviceWorkerStateProvider, sourceUriProvider, stateChangePrevious } from "./providers";
 
 test.afterEach(() => {
   //@ts-ignore
@@ -204,4 +204,32 @@ test('serviceWorkerStateProvider returns active when navigator.serviceWorker.con
   }
   const payload = serviceWorkerStateProvider(fakeWindow as Window)()();
   t.is(payload.serviceWorker, 'active');
+});
+
+test('stateChangePrevious provides previous', (t) => {
+  const provider = stateChangePrevious();
+
+  t.deepEqual(provider({stateType: 'type1', current: 'someValue'})(), {
+    previous: null,
+  });
+  t.deepEqual(provider({stateType: 'type1', current: 'someOtherValue'})(), {
+    previous: 'someValue',
+  });
+});
+
+test('stateChangePrevious provides namespaced previous', (t) => {
+  const provider = stateChangePrevious();
+
+  t.deepEqual(provider({stateType: 'type1', current: 'someValue1'})(), {
+    previous: null,
+  });
+  t.deepEqual(provider({stateType: 'type2', current: 'someValue2'})(), {
+    previous: null,
+  });
+  t.deepEqual(provider({stateType: 'type2', current: 'someOtherValue2'})(), {
+    previous: 'someValue2',
+  });
+  t.deepEqual(provider({stateType: 'type1', current: 'someOtherValue1'})(), {
+    previous: 'someValue1',
+  });
 });

--- a/src/providers.spec.ts
+++ b/src/providers.spec.ts
@@ -210,7 +210,7 @@ test('stateChangePrevious provides previous', (t) => {
   const provider = stateChangePrevious();
 
   t.deepEqual(provider({stateType: 'type1', current: 'someValue'})(), {
-    previous: null,
+    previous: 'none',
   });
   t.deepEqual(provider({stateType: 'type1', current: 'someOtherValue'})(), {
     previous: 'someValue',
@@ -221,10 +221,10 @@ test('stateChangePrevious provides namespaced previous', (t) => {
   const provider = stateChangePrevious();
 
   t.deepEqual(provider({stateType: 'type1', current: 'someValue1'})(), {
-    previous: null,
+    previous: 'none',
   });
   t.deepEqual(provider({stateType: 'type2', current: 'someValue2'})(), {
-    previous: null,
+    previous: 'none',
   });
   t.deepEqual(provider({stateType: 'type2', current: 'someOtherValue2'})(), {
     previous: 'someValue2',

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -58,7 +58,7 @@ export const stateChangePrevious = () => {
   const cache: {[ns: string]: string} = {}
 
   return (params: {stateType: string; current: string;}) => {
-    const previous = cache[params.stateType] || null;
+    const previous = cache[params.stateType] || 'none';
     cache[params.stateType] = params.current;
     return () => ({previous})
   };

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -53,3 +53,13 @@ export const sourceUriProvider = (windowInput?: Window) => {
     sourceUri: (params && params.sourceUri) ?? (win ? win.location.toString() : ''),
   });
 };
+
+export const stateChangePrevious = () => {
+  const cache: {[ns: string]: string} = {}
+
+  return (params: {stateType: string; current: string;}) => {
+    const previous = cache[params.stateType] || null;
+    cache[params.stateType] = params.current;
+    return () => ({previous})
+  };
+};


### PR DESCRIPTION
this will allow submitting state changes without keeping track of what the previous state was in memory, which is important because we're merging like 3 or 4 event handlers into the visibility state

i briefly tried to make the provider a more abstract "forward x field from previous event to y field on the next event with optional namespace provided by z field" but the typescript was annoying so i decided we could re-approach that if we have more use cases for it
